### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.7
         with:
           token: ${{ secrets.GIT_BOT_TOKEN }}
           fetch-depth: 0
 
       - name: Generate a changelog
-        uses: orhun/git-cliff-action@v3
+        uses: orhun/git-cliff-action@v3.2.0
         with:
           config: cliff.toml
           args: --verbose
@@ -28,7 +28,7 @@ jobs:
         
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v2
+        uses: crazy-max/ghaction-import-gpg@v6.1.0
         with:
           git_user_signingkey: true
           git_commit_gpgsign: true

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -12,7 +12,7 @@ jobs:
       has_new_commits: ${{ steps.check-for-commits.outputs.has_new_commits }}
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.1.7
 
       - name: Get the date of the last run
         id: last-run
@@ -36,7 +36,7 @@ jobs:
     if: ${{ needs.check-commits.outputs.has_new_commits == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.1.7
         
       - name: Delete old nightly tags
         if: needs.check-commits.outputs.has_new_commits == 'true'
@@ -52,7 +52,7 @@ jobs:
       - name: Create a new release
         if: needs.check-commits.outputs.has_new_commits == 'true' || github.event_name == 'workflow_dispatch'
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@v1.1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.7](https://github.com/actions/checkout/releases/tag/v4.1.7)** on 2024-06-12T19:05:21Z
* **[actions/create-release](https://github.com/actions/create-release)** published a new release **[v1.1.4](https://github.com/actions/create-release/releases/tag/v1.1.4)** on 2020-09-14T13:55:07Z
* **[crazy-max/ghaction-import-gpg](https://github.com/crazy-max/ghaction-import-gpg)** published a new release **[v6.1.0](https://github.com/crazy-max/ghaction-import-gpg/releases/tag/v6.1.0)** on 2023-12-26T16:55:59Z
* **[orhun/git-cliff-action](https://github.com/orhun/git-cliff-action)** published a new release **[v3.2.0](https://github.com/orhun/git-cliff-action/releases/tag/v3.2.0)** on 2024-06-03T13:15:28Z
