### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -40,7 +40,7 @@ jobs:
     needs: release
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.7
 
       - name: Extract Version
         id: extract_version
@@ -51,7 +51,7 @@ jobs:
 
       - name: Create and Upload Release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.0.8
         with:
           tag_name: nightly
           name: Nightly Release ${{ env.version }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.7](https://github.com/actions/checkout/releases/tag/v4.1.7)** on 2024-06-12T19:05:21Z
* **[softprops/action-gh-release](https://github.com/softprops/action-gh-release)** published a new release **[v2.0.8](https://github.com/softprops/action-gh-release/releases/tag/v2.0.8)** on 2024-07-18T21:40:03Z
