### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Generate a changelog
-        uses: orhun/git-cliff-action@v3.2.0
+        uses: orhun/git-cliff-action@v3.3.0
         with:
           config: cliff.toml
           args: --verbose


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[orhun/git-cliff-action](https://github.com/orhun/git-cliff-action)** published a new release **[v3.3.0](https://github.com/orhun/git-cliff-action/releases/tag/v3.3.0)** on 2024-07-27T19:35:06Z
