### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Generate a changelog
-        uses: orhun/git-cliff-action@v3.3.0
+        uses: orhun/git-cliff-action@v4.0.0
         with:
           config: cliff.toml
           args: --verbose


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[orhun/git-cliff-action](https://github.com/orhun/git-cliff-action)** published a new release **[v4.0.0](https://github.com/orhun/git-cliff-action/releases/tag/v4.0.0)** on 2024-08-26T19:25:25Z
