### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/keep-workflow-packages-up-to-date.yml
+++ b/.github/workflows/keep-workflow-packages-up-to-date.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.GIT_BOT_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
         with:
           token: ${{ secrets.GIT_BOT_TOKEN }}
           fetch-depth: 0
@@ -28,7 +28,7 @@ jobs:
         
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v6.1.0
+        uses: crazy-max/ghaction-import-gpg@v6.2.0
         with:
           gpg_private_key: ${{ secrets.GIT_ACTIONS_GPG_KEY }}
           git_user_signingkey: true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
* **[crazy-max/ghaction-import-gpg](https://github.com/crazy-max/ghaction-import-gpg)** published a new release **[v6.2.0](https://github.com/crazy-max/ghaction-import-gpg/releases/tag/v6.2.0)** on 2024-10-26T19:14:49Z
