### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Generate a changelog
-        uses: orhun/git-cliff-action@v4.3.1
+        uses: orhun/git-cliff-action@v4.4.1
         with:
           config: cliff.toml
           args: --verbose


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[orhun/git-cliff-action](https://github.com/orhun/git-cliff-action)** published a new release **[v4.4.1](https://github.com/orhun/git-cliff-action/releases/tag/v4.4.1)** on 2024-11-28T21:00:28Z
